### PR TITLE
Kalibro processor

### DIFF
--- a/Dockerfile-centos
+++ b/Dockerfile-centos
@@ -35,4 +35,4 @@ RUN gem install bundler thor --no-ri --no-rdoc
 
 ADD scripts /root/mezuro/scripts
 
-CMD ["/root/mezuro/scripts/kalibro_configurations/run.sh"]
+CMD ["/root/mezuro/scripts/run_all.sh"]

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -28,4 +28,4 @@ RUN gem install bundler thor --no-ri --no-rdoc
 
 ADD scripts /root/mezuro/scripts
 
-CMD ["/root/mezuro/scripts/kalibro_configurations/run.sh"]
+CMD ["/root/mezuro/scripts/run_all.sh"]

--- a/Rakefile
+++ b/Rakefile
@@ -1,20 +1,53 @@
-task default: %w[centos debian]
+task default: %w[centos:all debian:all]
 
-desc 'Build the whole Mezuro packages for Debian'
-task :debian => [:mk_structure] do
-  sh 'docker build --rm=true --tag mezuro-debian-build -f Dockerfile-debian .'
-  sh "docker run -t -i --volume=#{Dir.pwd}/pkgs:/root/mezuro/pkgs mezuro-debian-build"
+namespace :debian do
+  desc 'Build the whole Mezuro packages for Debian'
+  task :all => [:container] do
+    sh "docker run -t -i --volume=#{Dir.pwd}/pkgs:/root/mezuro/pkgs mezuro-debian-build"
+  end
+
+  desc 'Build the KalibroConfigurations package for Debian'
+  task :kalibro_configurations => [:container] do
+    sh "docker run -t -i --volume=#{Dir.pwd}/pkgs:/root/mezuro/pkgs mezuro-debian-build bash /root/mezuro/scripts/kalibro_configurations/run.sh"
+  end
+
+  desc 'Build the KalibroProcessor package for Debian'
+  task :kalibro_processor => [:container] do
+    sh "docker run -t -i --volume=#{Dir.pwd}/pkgs:/root/mezuro/pkgs mezuro-debian-build bash /root/mezuro/scripts/kalibro_processor/run.sh"
+  end
+
+  desc 'Build the whole Docker containerfor Debian'
+  task :container => [:mk_structure] do
+    sh 'docker build --rm=true --tag mezuro-debian-build -f Dockerfile-debian .'
+  end
 end
 
-desc 'Build the whole Mezuro packages for CentOS'
-task :centos => [:mk_structure] do
-  sh 'docker build --rm=true --tag mezuro-centos-build -f Dockerfile-centos .'
-  sh "docker run -t -i --volume=#{Dir.pwd}/pkgs:/root/mezuro/pkgs mezuro-centos-build"
+namespace :centos do
+  desc 'Build the whole Mezuro packages for CentOS'
+  task :all => [:container, :kalibro_configurations, :kalibro_processor] do
+    sh "docker run -t -i --volume=#{Dir.pwd}/pkgs:/root/mezuro/pkgs mezuro-centos-build"
+  end
+
+  desc 'Build the KalibroConfigurations package for CentOS'
+  task :kalibro_configurations do
+    sh "docker run -t -i --volume=#{Dir.pwd}/pkgs:/root/mezuro/pkgs mezuro-centos-build bash /root/mezuro/scripts/kalibro_configurations/run.sh"
+  end
+
+  desc 'Build the KalibroProcessor package for CentOS'
+  task :kalibro_processor do
+    sh "docker run -t -i --volume=#{Dir.pwd}/pkgs:/root/mezuro/pkgs mezuro-centos-build bash /root/mezuro/scripts/kalibro_processor/run.sh"
+  end
+
+  desc 'Build the whole Docker containerfor CentOS'
+  task :container => [:mk_structure] do
+    sh 'docker build --rm=true --tag mezuro-centos-build -f Dockerfile-centos .'
+  end
 end
 
-desc 'Create build dirs and fetch source files'
+desc 'Create build dirs'
 task :mk_structure do
   sh "mkdir -p pkgs/kalibro_configurations"
+  sh "mkdir -p pkgs/kalibro_processor"
 end
 
 desc 'Undo mk_structure'

--- a/Rakefile
+++ b/Rakefile
@@ -24,17 +24,17 @@ end
 
 namespace :centos do
   desc 'Build the whole Mezuro packages for CentOS'
-  task :all => [:container, :kalibro_configurations, :kalibro_processor] do
+  task :all => [:container] do
     sh "docker run -t -i --volume=#{Dir.pwd}/pkgs:/root/mezuro/pkgs mezuro-centos-build"
   end
 
   desc 'Build the KalibroConfigurations package for CentOS'
-  task :kalibro_configurations do
+  task :kalibro_configurations => [:container] do
     sh "docker run -t -i --volume=#{Dir.pwd}/pkgs:/root/mezuro/pkgs mezuro-centos-build bash /root/mezuro/scripts/kalibro_configurations/run.sh"
   end
 
   desc 'Build the KalibroProcessor package for CentOS'
-  task :kalibro_processor do
+  task :kalibro_processor => [:container] do
     sh "docker run -t -i --volume=#{Dir.pwd}/pkgs:/root/mezuro/pkgs mezuro-centos-build bash /root/mezuro/scripts/kalibro_processor/run.sh"
   end
 

--- a/scripts/kalibro_processor/recipe.rb
+++ b/scripts/kalibro_processor/recipe.rb
@@ -22,7 +22,7 @@ class KalibroProcessor < FPM::Cookery::Recipe
     depends 'postgresql', 'postgresql-server', 'ruby', 'ruby-devel', 'gcc', 'gcc-c++', 'patch', 'zlib-devel', 'rubygem-bundler', 'sqlite-devel', 'postgresql-devel', 'redhat-rpm-config'
   when :debian
     then
-    depends 'postgresql', 'ruby', 'bundler', 'libsqlite3-dev', 'postgresql-server-dev-9.4'
+    depends 'postgresql', 'ruby', 'bundler', 'libsqlite3-dev', 'postgresql-server-dev-9.4', 'git'
   end
 
   post_install "post_install.rb"

--- a/scripts/kalibro_processor/recipe.rb
+++ b/scripts/kalibro_processor/recipe.rb
@@ -1,0 +1,52 @@
+require_relative '../generate_post_install'
+
+class KalibroProcessor < FPM::Cookery::Recipe
+  include GeneratePostInstall
+
+  name     'kalibro-processor'
+  version  '1.1.3'
+  source   'https://github.com/mezuro/kalibro_processor.git', :with => :git, :tag => "v#{version}"
+
+  maintainer  'Mezuro Team <mezurometrics@gmail.com>'
+  license     'AGPLv3'
+  description 'Web service for managing code analysis configurations'
+  arch        'all'
+
+  revision '1'
+
+  config_files '/etc/mezuro/kalibro-processor/database.yml', '/etc/mezuro/kalibro-processor/secrets.yml', '/etc/mezuro/kalibro-processor/repositories.yml'
+
+  case platform
+  when :centos
+    then
+    depends 'postgresql', 'postgresql-server', 'ruby', 'ruby-devel', 'gcc', 'gcc-c++', 'patch', 'zlib-devel', 'rubygem-bundler', 'sqlite-devel', 'postgresql-devel', 'redhat-rpm-config'
+  when :debian
+    then
+    depends 'postgresql', 'ruby', 'bundler', 'libsqlite3-dev', 'postgresql-server-dev-9.4'
+  end
+
+  post_install "post_install.rb"
+
+  def build
+    inline_replace 'config/database.yml.sample' do |s|
+      s.gsub! /^(\s*)username:(.*)/, ''
+      s.gsub! /^(\s*)password:(.*)/, ''
+    end
+
+    generate_post_install("#{File.dirname(__FILE__)}/post_install.rb", 'kalibro-processor', 8083)
+
+    safesystem("bundle package --all --all-platforms")
+  end
+
+  def install
+    etc('mezuro/kalibro-processor').install 'config/database.yml.sample', 'database.yml'
+    ln_s '/etc/mezuro/kalibro-processor/database.yml', 'config/database.yml'
+    etc('mezuro/kalibro-processor').install 'config/secrets.yml', 'secrets.yml'
+    rm 'config/secrets.yml'
+    ln_s '/etc/mezuro/kalibro-processor/secrets.yml', 'config/secrets.yml'
+    etc('mezuro/kalibro-processor').install 'config/repositories.yml.sample', 'repositories.yml'
+    ln_s '/etc/mezuro/kalibro-processor/repositories.yml', 'config/repositories.yml'
+    share('mezuro/kalibro-processor').install Dir['*']
+    share('mezuro/kalibro-processor').install %w(.bundle .env)
+  end
+end

--- a/scripts/kalibro_processor/recipe.rb
+++ b/scripts/kalibro_processor/recipe.rb
@@ -9,7 +9,7 @@ class KalibroProcessor < FPM::Cookery::Recipe
 
   maintainer  'Mezuro Team <mezurometrics@gmail.com>'
   license     'AGPLv3'
-  description 'Web service for managing code analysis configurations'
+  description 'Web service for static source code analysis'
   arch        'all'
 
   revision '1'
@@ -33,7 +33,7 @@ class KalibroProcessor < FPM::Cookery::Recipe
       s.gsub! /^(\s*)password:(.*)/, ''
     end
 
-    generate_post_install("#{File.dirname(__FILE__)}/post_install.rb", 'kalibro-processor', 8083)
+    generate_post_install("#{File.dirname(__FILE__)}/post_install.rb", 'kalibro-processor', 8082)
 
     safesystem("bundle package --all --all-platforms")
   end

--- a/scripts/kalibro_processor/recipe.rb
+++ b/scripts/kalibro_processor/recipe.rb
@@ -19,7 +19,7 @@ class KalibroProcessor < FPM::Cookery::Recipe
   case platform
   when :centos
     then
-    depends 'postgresql', 'postgresql-server', 'ruby', 'ruby-devel', 'gcc', 'gcc-c++', 'patch', 'zlib-devel', 'rubygem-bundler', 'sqlite-devel', 'postgresql-devel', 'redhat-rpm-config'
+    depends 'postgresql', 'postgresql-server', 'ruby', 'ruby-devel', 'gcc', 'gcc-c++', 'patch', 'zlib-devel', 'rubygem-bundler', 'sqlite-devel', 'postgresql-devel', 'redhat-rpm-config', 'git'
   when :debian
     then
     depends 'postgresql', 'ruby', 'bundler', 'libsqlite3-dev', 'postgresql-server-dev-9.4', 'git'

--- a/scripts/kalibro_processor/run.sh
+++ b/scripts/kalibro_processor/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+systemctl start postgresql
+fpm-cook package --pkg-dir /root/mezuro/pkgs/kalibro_processor /root/mezuro/scripts/kalibro_processor/recipe.rb

--- a/scripts/run_all.sh
+++ b/scripts/run_all.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+for application in /root/mezuro/scripts/*/ ; do
+  bash $application/run.sh
+done


### PR DESCRIPTION
Rakefile was refactored to avoid duplications. Now it is possible to build a single package for a specific project or to build packages for all projects.

By default, all scripts `run.sh` of the projects are run.
