### PR TITLE
Recipe informations

### DIFF
--- a/Dockerfile-centos
+++ b/Dockerfile-centos
@@ -34,5 +34,6 @@ RUN gem install fpm-cookery --no-ri --no-rdoc
 RUN gem install bundler thor --no-ri --no-rdoc
 
 ADD scripts /root/mezuro/scripts
+ADD mezuro_informations.rb /root/mezuro/mezuro_informations.rb
 
 CMD ["/bin/bash"]

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -27,5 +27,6 @@ RUN gem install fpm-cookery --no-ri --no-rdoc
 RUN gem install bundler thor --no-ri --no-rdoc
 
 ADD scripts /root/mezuro/scripts
+ADD mezuro_informations.rb /root/mezuro/mezuro_informations.rb
 
 CMD ["/bin/bash"]

--- a/Rakefile
+++ b/Rakefile
@@ -18,9 +18,9 @@ namespace :debian do
   desc 'Build the whole Mezuro packages for Debian'
   task :all => [:prezento]
 
-  kalibro_configurations_deb = deb_path('kalibro-configurations', MezuroInformations::KALIBRO_CONFIGURATIONS)
-  kalibro_processor_deb = deb_path('kalibro-processor', MezuroInformations::KALIBRO_PROCESSOR)
-  prezento_deb = deb_path('prezento', MezuroInformations::PREZENTO)
+  kalibro_configurations_deb = deb_path('kalibro-configurations', MezuroInformations::KALIBRO_CONFIGURATIONS[:info])
+  kalibro_processor_deb = deb_path('kalibro-processor', MezuroInformations::KALIBRO_PROCESSOR[:info])
+  prezento_deb = deb_path('prezento', MezuroInformations::PREZENTO[:info])
 
   desc 'Build the KalibroConfigurations package for Debian'
   task :kalibro_configurations => [:container, kalibro_configurations_deb]
@@ -64,9 +64,9 @@ namespace :centos do
   task :all => :prezento do
   end
 
-  kalibro_configurations_rpm = rpm_path('kalibro-configurations', MezuroInformations::KALIBRO_CONFIGURATIONS)
-  kalibro_processor_rpm = rpm_path('kalibro-processor', MezuroInformations::KALIBRO_PROCESSOR)
-  prezento_rpm = rpm_path('prezento', MezuroInformations::PREZENTO)
+  kalibro_configurations_rpm = rpm_path('kalibro-configurations', MezuroInformations::KALIBRO_CONFIGURATIONS[:info])
+  kalibro_processor_rpm = rpm_path('kalibro-processor', MezuroInformations::KALIBRO_PROCESSOR[:info])
+  prezento_rpm = rpm_path('prezento', MezuroInformations::PREZENTO[:info])
 
   desc 'Build the KalibroConfigurations package for CentOS'
   task :kalibro_configurations => [:container, kalibro_configurations_rpm]

--- a/helpers/publisher_helper.rb
+++ b/helpers/publisher_helper.rb
@@ -16,15 +16,11 @@ module Helpers
 
       puts ">> Uploading package on #{path}"
       if type == 'deb'
-        ContentManager.debian_upload(type, package, version, "#{package}/#{package}-#{version}",
-        {distros: 'Jessie', components: 'main', archs: 'all'}, path)
+        ContentManager.debian_upload(type, package, version, "#{package}-#{version}_all.deb",
+        {distros: 'jessie', components: 'main', archs: 'all'}, path)
       else
         ContentManager.upload(type, package, version, "#{package}-#{version}", path)
       end
-
-      puts ">> Publishing"
-      ContentManager.publish(type, package, version)
-      ContentManager.calc_metadata(type)
     end
   end
 end

--- a/helpers/publisher_helper.rb
+++ b/helpers/publisher_helper.rb
@@ -19,7 +19,7 @@ module Helpers
         ContentManager.debian_upload(type, package, version, "#{package}-#{version}_all.deb",
         {distros: 'jessie', components: 'main', archs: 'all'}, path)
       else
-        ContentManager.upload(type, package, version, "#{package}-#{version}", path)
+        ContentManager.upload(type, package, version, "#{package}-#{version}.noarch.rpm", path)
       end
     end
   end

--- a/helpers/publisher_helper.rb
+++ b/helpers/publisher_helper.rb
@@ -19,11 +19,12 @@ module Helpers
         ContentManager.debian_upload(type, package, version, "#{package}/#{package}-#{version}",
         {distros: 'Jessie', components: 'main', archs: 'all'}, path)
       else
-        ContentManager.upload(type, package, version, "#{package}/#{package}-#{version}", path)
+        ContentManager.upload(type, package, version, "#{package}-#{version}", path)
       end
 
       puts ">> Publishing"
       ContentManager.publish(type, package, version)
+      ContentManager.calc_metadata(type)
     end
   end
 end

--- a/mezuro_informations.rb
+++ b/mezuro_informations.rb
@@ -1,5 +1,5 @@
 module MezuroInformations
-  KALIBRO_PROCESSOR = { info: { version: '1.1.5', release: '1' },
+  KALIBRO_PROCESSOR = { info: { version: '1.1.5', release: '2' },
                         data: { name: 'kalibro-processor',
                                 desc: 'Web service for static source code analysis',
                                 labels: ['web service', 'code analysis', 'source code metrics'],
@@ -9,7 +9,7 @@ module MezuroInformations
                                 issue_tracker_url: 'https://github.com/mezuro/kalibro_processor/issues',
                                 public_download_numbers: true }
                       }
-  KALIBRO_CONFIGURATIONS = { info: { version: '1.2.5', release: '1' },
+  KALIBRO_CONFIGURATIONS = { info: { version: '1.2.5', release: '2' },
                              data: { name: 'kalibro-configurations',
                                      desc: 'Web service for managing code analysis configurations',
                                      labels: ['web service', 'source code metrics', 'metric configurations'],
@@ -19,7 +19,7 @@ module MezuroInformations
                                      issue_tracker_url: 'https://github.com/mezuro/kalibro_configurations/issues',
                                      public_download_numbers: true }
                            }
-  PREZENTO = { info: { version: '0.10.0', release: '1' },
+  PREZENTO = { info: { version: '0.10.0', release: '2' },
                data: { name: 'prezento',
                        desc: 'Collaborative code metrics',
                        labels: ['web interface', 'source code metrics'],

--- a/scripts/bintray/content_manager.rb
+++ b/scripts/bintray/content_manager.rb
@@ -23,4 +23,8 @@ class ContentManager
   def self.delete(repo, file_path)
     RequestMaker.delete("/content/:user/#{repo}/#{file_path}")
   end
+
+  def self.calc_metadata(repo)
+    RequestMaker.post("/calc_metadata/:user/#{repo}")
+  end
 end

--- a/scripts/bintray/content_manager.rb
+++ b/scripts/bintray/content_manager.rb
@@ -11,7 +11,7 @@ class ContentManager
     response = RequestMaker.put("/content/:user/#{repo}/#{package}/#{version}/#{file_path};" \
                       "deb_distribution=#{debian_info[:distros]};" \
                       "deb_component=#{debian_info[:components]};" \
-                      "deb_architecture=#{debian_info[:archs]}", file_bin)
+                      "deb_architecture=#{debian_info[:archs]};publish=1", file_bin)
     file_bin.close
     response
   end
@@ -22,9 +22,5 @@ class ContentManager
 
   def self.delete(repo, file_path)
     RequestMaker.delete("/content/:user/#{repo}/#{file_path}")
-  end
-
-  def self.calc_metadata(repo)
-    RequestMaker.post("/calc_metadata/:user/#{repo}")
   end
 end

--- a/scripts/bintray/content_manager.rb
+++ b/scripts/bintray/content_manager.rb
@@ -1,7 +1,7 @@
 class ContentManager
   def self.upload(repo, package, version, file_path, file)
     file_bin = File.open(file, 'rb')
-    response = RequestMaker.put("/content/:user/#{repo}/#{package}/#{version}/#{file_path}", file_bin)
+    response = RequestMaker.put("/content/:user/#{repo}/#{package}/#{version}/#{file_path}?publish=1", file_bin)
     file_bin.close
     response
   end

--- a/scripts/kalibro_configurations/recipe.rb
+++ b/scripts/kalibro_configurations/recipe.rb
@@ -48,6 +48,6 @@ class KalibroConfigurations < FPM::Cookery::Recipe
     ln_s '/etc/mezuro/kalibro-configurations/secrets.yml', 'config/secrets.yml'
     share('mezuro/kalibro-configurations').install Dir['*']
     share('mezuro/kalibro-configurations').install %w(.bundle .env)
-    bin('kalibro-configurations-admin').install builddir('admin.sh')
+    bin.install builddir('admin.sh'), 'kalibro-configurations-admin'
   end
 end

--- a/scripts/kalibro_configurations/recipe.rb
+++ b/scripts/kalibro_configurations/recipe.rb
@@ -3,13 +3,13 @@ require_relative '../generate_script'
 class KalibroConfigurations < FPM::Cookery::Recipe
   include GenerateScript
 
-  name     'kalibro-configurations'
-  version  '1.2.3'
-  source   'https://github.com/mezuro/kalibro_configurations.git', :with => :git, :tag => "v#{version}"
+  name     MezuroInformations::KALIBRO_CONFIGURATIONS[:data][:name]
+  version  MezuroInformations::KALIBRO_CONFIGURATIONS[:info][:version]
+  source   MezuroInformations::KALIBRO_CONFIGURATIONS[:data][:vcs_url], :with => :git, :tag => "v#{version}"
 
   maintainer  'Mezuro Team <mezurometrics@gmail.com>'
-  license     'AGPLv3'
-  description 'Web service for managing code analysis configurations'
+  license     MezuroInformations::KALIBRO_CONFIGURATIONS[:data][:licenses][0]
+  description MezuroInformations::KALIBRO_CONFIGURATIONS[:data][:desc]
   arch        'all'
 
   revision '1'

--- a/scripts/kalibro_configurations/recipe.rb
+++ b/scripts/kalibro_configurations/recipe.rb
@@ -13,7 +13,7 @@ class KalibroConfigurations < FPM::Cookery::Recipe
   description MezuroInformations::KALIBRO_CONFIGURATIONS[:data][:desc]
   arch        'all'
 
-  revision '1'
+  revision MezuroInformations::KALIBRO_PROCESSOR[:info][:release]
 
   config_files '/etc/mezuro/kalibro-configurations/database.yml', '/etc/mezuro/kalibro-configurations/secrets.yml'
 

--- a/scripts/kalibro_configurations/recipe.rb
+++ b/scripts/kalibro_configurations/recipe.rb
@@ -1,4 +1,5 @@
 require_relative '../generate_script'
+require_relative '../../mezuro_informations'
 
 class KalibroConfigurations < FPM::Cookery::Recipe
   include GenerateScript

--- a/scripts/kalibro_processor/recipe.rb
+++ b/scripts/kalibro_processor/recipe.rb
@@ -1,4 +1,5 @@
 require_relative '../generate_script'
+require_relative '../../mezuro_informations'
 
 class KalibroProcessor < FPM::Cookery::Recipe
   include GenerateScript

--- a/scripts/kalibro_processor/recipe.rb
+++ b/scripts/kalibro_processor/recipe.rb
@@ -3,13 +3,13 @@ require_relative '../generate_script'
 class KalibroProcessor < FPM::Cookery::Recipe
   include GenerateScript
 
-  name     'kalibro-processor'
-  version  '1.1.3'
-  source   'https://github.com/mezuro/kalibro_processor.git', :with => :git, :tag => "v#{version}"
+  name     MezuroInformations::KALIBRO_PROCESSOR[:data][:name]
+  version  MezuroInformations::KALIBRO_PROCESSOR[:info][:version]
+  source   MezuroInformations::KALIBRO_PROCESSOR[:data][:vcs_url], :with => :git, :tag => "v#{version}"
 
   maintainer  'Mezuro Team <mezurometrics@gmail.com>'
-  license     'AGPLv3'
-  description 'Web service for static source code analysis'
+  license     MezuroInformations::KALIBRO_PROCESSOR[:data][:licenses][0]
+  description MezuroInformations::KALIBRO_PROCESSOR[:data][:desc]
   arch        'all'
 
   revision '1'

--- a/scripts/kalibro_processor/recipe.rb
+++ b/scripts/kalibro_processor/recipe.rb
@@ -50,6 +50,6 @@ class KalibroProcessor < FPM::Cookery::Recipe
     ln_s '/etc/mezuro/kalibro-processor/repositories.yml', 'config/repositories.yml'
     share('mezuro/kalibro-processor').install Dir['*']
     share('mezuro/kalibro-processor').install %w(.bundle .env)
-    bin('kalibro-processor-admin').install builddir('admin.sh')
+    bin.install builddir('admin.sh'), 'kalibro-processor-admin'
   end
 end

--- a/scripts/kalibro_processor/recipe.rb
+++ b/scripts/kalibro_processor/recipe.rb
@@ -13,7 +13,7 @@ class KalibroProcessor < FPM::Cookery::Recipe
   description MezuroInformations::KALIBRO_PROCESSOR[:data][:desc]
   arch        'all'
 
-  revision '1'
+  revision MezuroInformations::KALIBRO_PROCESSOR[:info][:release]
 
   config_files '/etc/mezuro/kalibro-processor/database.yml', '/etc/mezuro/kalibro-processor/secrets.yml', '/etc/mezuro/kalibro-processor/repositories.yml'
 

--- a/scripts/post_install.sh
+++ b/scripts/post_install.sh
@@ -50,7 +50,7 @@ if systemctl start postgresql; then
     $admin_bin rake db:migrate > /dev/null || :
 
     cat <<EOF
-${name} database successfully created. If you want to populate it with default data, please run `$admin_bin rake db:seed`.
+${name} database successfully created. If you want to populate it with default data, please run '$admin_bin rake db:seed'.
 NOTICE: errors may be risen if the required services are not running.
 EOF
   fi

--- a/scripts/prezento/recipe.rb
+++ b/scripts/prezento/recipe.rb
@@ -48,6 +48,6 @@ class Prezento < FPM::Cookery::Recipe
     ln_s '/etc/mezuro/prezento/secrets.yml', 'config/secrets.yml'
     share('mezuro/prezento').install Dir['*']
     share('mezuro/prezento').install %w(.bundle .env)
-    bin('prezento-admin').install builddir('admin.sh')
+    bin.install builddir('admin.sh'), 'prezento-admin'
   end
 end

--- a/scripts/prezento/recipe.rb
+++ b/scripts/prezento/recipe.rb
@@ -1,15 +1,16 @@
 require_relative '../generate_script'
+require_relative '../../mezuro_informations'
 
 class Prezento < FPM::Cookery::Recipe
   include GenerateScript
 
-  name     'prezento'
-  version  '0.9.2'
-  source   'https://github.com/mezuro/prezento.git', :with => :git, :tag => "v#{version}"
+  name     MezuroInformations::PREZENTO[:data][:name]
+  version  MezuroInformations::PREZENTO[:info][:version]
+  source   MezuroInformations::PREZENTO[:data][:vcs_url], :with => :git, :tag => "v#{version}"
 
   maintainer  'Mezuro Team <mezurometrics@gmail.com>'
-  license     'AGPLv3'
-  description 'Collaborative code metrics'
+  license     MezuroInformations::PREZENTO[:data][:licenses][0]
+  description MezuroInformations::PREZENTO[:data][:desc]
   arch        'all'
 
   revision '1'

--- a/scripts/prezento/recipe.rb
+++ b/scripts/prezento/recipe.rb
@@ -13,7 +13,7 @@ class Prezento < FPM::Cookery::Recipe
   description MezuroInformations::PREZENTO[:data][:desc]
   arch        'all'
 
-  revision '1'
+  revision MezuroInformations::PREZENTO[:info][:release]
 
   config_files '/etc/mezuro/prezento/database.yml', '/etc/mezuro/prezento/secrets.yml'
 


### PR DESCRIPTION
Here we have two fixes:
- `MezuroInformation` widespread usage (specially recipes): this ensures that we have informations like version in only one file making easy releases
- Package upload and publish: the upload has to create the file with its extension (.deb or .rpm) in order to get the metada properly generated
