### PR TITLE
Change ` to ' on post_install script cat input file

### DIFF
--- a/mezuro_informations.rb
+++ b/mezuro_informations.rb
@@ -1,5 +1,5 @@
 module MezuroInformations
-  KALIBRO_PROCESSOR = { info: { version: '1.1.5', release: '1' },
+  KALIBRO_PROCESSOR = { info: { version: '1.1.5', release: '2' },
                         data: { name: 'kalibro-processor',
                                 desc: 'Web service for static source code analysis',
                                 labels: ['web service', 'code analysis', 'source code metrics'],
@@ -9,7 +9,7 @@ module MezuroInformations
                                 issue_tracker_url: 'https://github.com/mezuro/kalibro_processor/issues',
                                 public_download_numbers: true }
                       }
-  KALIBRO_CONFIGURATIONS = { info: { version: '1.2.5', release: '1' },
+  KALIBRO_CONFIGURATIONS = { info: { version: '1.2.5', release: '2' },
                              data: { name: 'kalibro-configurations',
                                      desc: 'Web service for managing code analysis configurations',
                                      labels: ['web service', 'source code metrics', 'metric configurations'],
@@ -19,7 +19,7 @@ module MezuroInformations
                                      issue_tracker_url: 'https://github.com/mezuro/kalibro_configurations/issues',
                                      public_download_numbers: true }
                            }
-  PREZENTO = { info: { version: '0.10.0', release: '1' },
+  PREZENTO = { info: { version: '0.10.0', release: '2' },
                data: { name: 'prezento',
                        desc: 'Collaborative code metrics',
                        labels: ['web interface', 'source code metrics'],

--- a/scripts/kalibro_configurations/recipe.rb
+++ b/scripts/kalibro_configurations/recipe.rb
@@ -48,6 +48,6 @@ class KalibroConfigurations < FPM::Cookery::Recipe
     ln_s '/etc/mezuro/kalibro-configurations/secrets.yml', 'config/secrets.yml'
     share('mezuro/kalibro-configurations').install Dir['*']
     share('mezuro/kalibro-configurations').install %w(.bundle .env)
-    bin('kalibro-configurations-admin').install builddir('admin.sh')
+    bin.install builddir('admin.sh'), 'kalibro-configurations-admin'
   end
 end

--- a/scripts/kalibro_configurations/recipe.rb
+++ b/scripts/kalibro_configurations/recipe.rb
@@ -13,7 +13,7 @@ class KalibroConfigurations < FPM::Cookery::Recipe
   description MezuroInformations::KALIBRO_CONFIGURATIONS[:data][:desc]
   arch        'all'
 
-  revision '1'
+  revision MezuroInformations::KALIBRO_PROCESSOR[:info][:release]
 
   config_files '/etc/mezuro/kalibro-configurations/database.yml', '/etc/mezuro/kalibro-configurations/secrets.yml'
 

--- a/scripts/kalibro_processor/recipe.rb
+++ b/scripts/kalibro_processor/recipe.rb
@@ -50,6 +50,6 @@ class KalibroProcessor < FPM::Cookery::Recipe
     ln_s '/etc/mezuro/kalibro-processor/repositories.yml', 'config/repositories.yml'
     share('mezuro/kalibro-processor').install Dir['*']
     share('mezuro/kalibro-processor').install %w(.bundle .env)
-    bin('kalibro-processor-admin').install builddir('admin.sh')
+    bin.install builddir('admin.sh'), 'kalibro-processor-admin'
   end
 end

--- a/scripts/kalibro_processor/recipe.rb
+++ b/scripts/kalibro_processor/recipe.rb
@@ -13,7 +13,7 @@ class KalibroProcessor < FPM::Cookery::Recipe
   description MezuroInformations::KALIBRO_PROCESSOR[:data][:desc]
   arch        'all'
 
-  revision '1'
+  revision MezuroInformations::KALIBRO_PROCESSOR[:info][:release]
 
   config_files '/etc/mezuro/kalibro-processor/database.yml', '/etc/mezuro/kalibro-processor/secrets.yml', '/etc/mezuro/kalibro-processor/repositories.yml'
 

--- a/scripts/post_install.sh
+++ b/scripts/post_install.sh
@@ -50,7 +50,7 @@ if systemctl start postgresql; then
     $admin_bin rake db:migrate > /dev/null || :
 
     cat <<EOF
-${name} database successfully created. If you want to populate it with default data, please run `$admin_bin rake db:seed`.
+${name} database successfully created. If you want to populate it with default data, please run '$admin_bin rake db:seed'.
 NOTICE: errors may be risen if the required services are not running.
 EOF
   fi

--- a/scripts/prezento/recipe.rb
+++ b/scripts/prezento/recipe.rb
@@ -48,6 +48,6 @@ class Prezento < FPM::Cookery::Recipe
     ln_s '/etc/mezuro/prezento/secrets.yml', 'config/secrets.yml'
     share('mezuro/prezento').install Dir['*']
     share('mezuro/prezento').install %w(.bundle .env)
-    bin('prezento-admin').install builddir('admin.sh')
+    bin.install builddir('admin.sh'), 'prezento-admin'
   end
 end

--- a/scripts/prezento/recipe.rb
+++ b/scripts/prezento/recipe.rb
@@ -13,7 +13,7 @@ class Prezento < FPM::Cookery::Recipe
   description MezuroInformations::PREZENTO[:data][:desc]
   arch        'all'
 
-  revision '1'
+  revision MezuroInformations::PREZENTO[:info][:release]
 
   config_files '/etc/mezuro/prezento/database.yml', '/etc/mezuro/prezento/secrets.yml'
 


### PR DESCRIPTION
It was actually executing a command instead of just interpolating the
string. This behaviour generated an empty string after 'please run'

Signed off by: Eduardo Araújo duduktamg@hotmail.com
