### PR TITLE
Add which to centos dockerfile dependencies

### DIFF
--- a/Dockerfile-centos
+++ b/Dockerfile-centos
@@ -28,7 +28,8 @@ RUN yum -y install \
   postgresql \
   postgresql-devel \
   postgresql-server \
-  redhat-rpm-config
+  redhat-rpm-config \
+  which
 
 RUN gem install fpm-cookery --no-ri --no-rdoc
 RUN gem install bundler thor --no-ri --no-rdoc


### PR DESCRIPTION
Recent images of CentOS 7 may come without the which program breaking
fpm-cookery then.
