### PR TITLE
Create tmp dir on postinstall

### DIFF
--- a/scripts/post_install.sh
+++ b/scripts/post_install.sh
@@ -56,6 +56,8 @@ EOF
   fi
 fi
 
+$admin_bin rake tmp:create > /dev/null || :
+
 # Restart the service if it was running
 if [ $WAS_RUNNING -ne 0 ]; then
   systemctl start ${name}.target || :


### PR DESCRIPTION
This ensures that the folder exists and the application user owns it.

This is a workaround since, the correct behaviour with tmp would be
using a location at `/var/lib/...`.
