### PR TITLE
Prevent homedir removal on upgrade

### DIFF
--- a/scripts/post_uninstall.sh
+++ b/scripts/post_uninstall.sh
@@ -4,6 +4,6 @@ set -e
 
 homedir=
 
-if ! [[ -z "$1" ]] && ! [[ "$1" == upgrade ]] && ! [[ "$1" -ge 2 ]]; then
+if ! [[ -z "$1" ]] && ! [[ "$1" == upgrade ]] && ! [[ "$1" -eq 1 ]]; then
   rm -rf ${homedir}
 fi

--- a/scripts/post_uninstall.sh
+++ b/scripts/post_uninstall.sh
@@ -4,4 +4,6 @@ set -e
 
 homedir=
 
-rm -rf ${homedir}
+if ! [[ -z "$1" ]] && ! [[ "$1" == upgrade ]] && ! [[ "$1" -ge 2 ]]; then
+  rm -rf ${homedir}
+fi


### PR DESCRIPTION
The upgrade install both versions side by side and just after the
install of the new one removes the old. This is triggering the
postinstall script which was removing the homedir.

Both RPM and deb pass arguments to the script that permit to distinguish
upgrades from removals. But they do this differently forcing a more
complex conditional.

For further information check:
- On RPM - https://docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html/RPM_Guide/ch09s04s05.html
- On deb - https://wiki.debian.org/MaintainerScripts#Upgrading
